### PR TITLE
Lazy load document and window

### DIFF
--- a/src/controls/labels.ts
+++ b/src/controls/labels.ts
@@ -1,7 +1,7 @@
 import { ViewerMode, SheetLayout, SheetSize, SheetMarks } from '../constants';
 
 // TODO: This is not a particularly robust check.
-const supportsCustomSheetSize = !!window.hasOwnProperty('chrome');
+const supportsCustomSheetSize = () => !!window.hasOwnProperty('chrome');
 
 const getSheetSizeLabels = (pageSize: {
   width: string;
@@ -9,7 +9,7 @@ const getSheetSizeLabels = (pageSize: {
 }): [SheetSize, string][] => {
   const sizeName = `${pageSize.width} × ${pageSize.height}`;
 
-  if (!supportsCustomSheetSize) {
+  if (!supportsCustomSheetSize()) {
     return [
       [SheetSize.LETTER_PORTRAIT, 'Default Page Size *'],
       [

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -3,24 +3,22 @@ import prefixer from './prefixer';
 import safeMeasure from './safeMeasure';
 export * from './dom';
 
-const doc = window.document;
-
 // Create stylesheet with id
 const addStylesheet = (id: string): HTMLStyleElement => {
-  const style = doc.createElement('style');
+  const style = window.document.createElement('style');
   style.id = id;
-  doc.head.appendChild(style);
+  window.document.head.appendChild(style);
   return style;
 };
 
 // Fetch or create stylesheet with id
 const stylesheet = (id: string): HTMLStyleElement => {
-  return doc.querySelector(`#${id}`) ?? addStylesheet(id);
+  return window.document.querySelector(`#${id}`) ?? addStylesheet(id);
 };
 
 // Parse html from text
 const parseHTML = (text: string, selector?: string) => {
-  const wrapper = doc.createElement('div');
+  const wrapper = window.document.createElement('div');
   wrapper.innerHTML = text;
   return selector ? wrapper.querySelector(selector) : wrapper;
 };

--- a/src/page-setup/PageSetup.ts
+++ b/src/page-setup/PageSetup.ts
@@ -8,7 +8,7 @@ const letter = Object.freeze({ width: '8.5in', height: '11in' });
 const a4 = Object.freeze({ width: '210mm', height: '297mm' });
 
 // Not a really reliable way to know this
-const supportsCustomPageSize = !!window.hasOwnProperty('chrome');
+const supportsCustomPageSize = () => !!window.hasOwnProperty('chrome');
 
 // TODO: Refactor type checks for CSS lengths etc
 interface PageSetupOptions {
@@ -35,7 +35,7 @@ class PageSetup {
     this.margin = opts.margin ?? defaultPageSetup.margin;
     this.markLength = '12pt';
 
-    this.paper = supportsCustomPageSize
+    this.paper = supportsCustomPageSize()
       ? printOpts.paper || SheetSize.AUTO
       : SheetSize.AUTO_MARKS;
     this.bleed = printOpts.bleed ?? defaultPageSetup.bleed;

--- a/src/viewer/Viewer.ts
+++ b/src/viewer/Viewer.ts
@@ -19,7 +19,6 @@ import PageSetup from '../page-setup';
 const throttleProgressBar = throttleFrame();
 const throttleRender = throttleTime(100);
 const throttleResize = throttleTime(50);
-const document = window.document;
 
 const pageSpread = (...pgs: HTMLElement[]) => {
   return div('.spread-wrapper.spread-centered.spread-size', ...pgs);
@@ -141,11 +140,11 @@ class Viewer {
   }
 
   get isViewing() {
-    return document.body.classList.contains(classes.isViewing);
+    return window.document.body.classList.contains(classes.isViewing);
   }
 
   set isViewing(newVal) {
-    document.body.classList.toggle(classes.isViewing, newVal);
+    window.document.body.classList.toggle(classes.isViewing, newVal);
   }
 
   setSheetSize(newVal: SheetSize) {
@@ -205,7 +204,7 @@ class Viewer {
 
   show() {
     if (this.element.parentNode) return;
-    document.body.appendChild(this.element);
+    window.document.body.appendChild(this.element);
     this.isViewing = true;
   }
 
@@ -264,9 +263,9 @@ class Viewer {
     this.book = book;
     this.setProgressAmount(estimatedProgress);
 
-    if (!document.scrollingElement) return;
+    if (!window.document.scrollingElement) return;
 
-    const scroller = document.scrollingElement as HTMLElement;
+    const scroller = window.document.scrollingElement as HTMLElement;
     // don't bother rerendering if preview is out of view
     const scrollTop = scroller.scrollTop;
     const scrollH = scroller.scrollHeight;


### PR DESCRIPTION
This is a follow-up PR to this: https://github.com/evnbr/regionize/issues/3

With this PR, I can successfully write `Bindery.createRule()` in a node.js script without triggering any error.