### PR TITLE
Flipbook viewer cleanup / accessibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
   - 'node'
 install:
   - npm install
-script: npm run test-ci
+script: npm run test:ci

--- a/package.json
+++ b/package.json
@@ -47,12 +47,20 @@
   },
   "scripts": {
     "build": "tsc",
-    "package": "rollup -c",
-    "postbuild": "npm run package && npm run clean && npm run movetodocs",
+    "postbuild": "npm run package:prod && npm run clean",
+
+    "dev": "tsc",
+    "postdev": "npm run package:dev && npm run clean",
+
+    "package:dev": "rollup -c --environment BUILD:dev",
+    "package:prod": "rollup -c --environment BUILD:prod",
+
     "test": "jest",
     "test-ci": "npm run coverage && ./node_modules/.bin/codecov",
+
     "clean": "rimraf build",
-    "movetodocs": "cp dist/bindery.umd.js docs/bindery_local_build.js",
+    "postclean": "cp dist/bindery.umd.js docs/bindery_local_build.js",
+
     "coverage": "jest --coverage",
     "docs": "cd docs && jekyll serve"
   },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "package:prod": "rollup -c --environment BUILD:prod",
 
     "test": "jest",
-    "test-ci": "npm run coverage && ./node_modules/.bin/codecov",
+    "test:ci": "npm run coverage && ./node_modules/.bin/codecov",
 
     "clean": "rimraf build",
     "postclean": "cp dist/bindery.umd.js docs/bindery_local_build.js",

--- a/src/bindery.ts
+++ b/src/bindery.ts
@@ -4,6 +4,7 @@
 import PageSetup from './page-setup';
 import { ViewerMode, SheetSize, SheetLayout, SheetMarks } from './constants';
 import defaultRules from './defaults';
+import type { BookContent } from './types';
 
 // components
 import makeBook from './makeBook';
@@ -32,8 +33,7 @@ interface PrintSetup {
 interface BinderyOptions {
   autoupdate?: boolean;
   autorun?: boolean;
-  ControlsComponent?: any;
-  content?: HTMLElement;
+  content: BookContent;
   pageNumberOffset?: number;
   printSetup?: PrintSetup;
   pageSetup?: {};
@@ -49,7 +49,7 @@ class Bindery {
   pageSetup: PageSetup;
   rules: Rule[];
 
-  constructor(opts: BinderyOptions = {}) {
+  constructor(opts: BinderyOptions) {
     console.log(`📖 Bindery ${BINDERY_VERSION}`);
 
     validateRuntimeOptions(opts, {
@@ -95,7 +95,7 @@ class Bindery {
       throw Error('Bindery: You must include a source element or selector');
     }
 
-    if (opts.ControlsComponent) {
+    if (opts.hasOwnProperty('ControlsComponent')) {
       this.viewer.displayError(
         'Controls are now included',
         'Please remove the controls component',
@@ -119,7 +119,7 @@ class Bindery {
   }
 
   // Convenience constructor
-  static makeBook(opts: BinderyOptions = {}) {
+  static makeBook(opts: BinderyOptions) {
     opts.autorun = opts.autorun ?? true;
     return new Bindery(opts);
   }
@@ -129,7 +129,7 @@ class Bindery {
     if (this.content) this.content.style.display = '';
   }
 
-  async makeBook(contentDescription: any): Promise<Book | undefined> {
+  async makeBook(contentDescription: BookContent): Promise<Book | undefined> {
     try {
       this.content = await getContentAsElement(contentDescription);
     } catch (e) {

--- a/src/controls/components.ts
+++ b/src/controls/components.ts
@@ -5,11 +5,11 @@ const row = (cls: string | null, ...children: (HTMLElement | string)[]) => {
 };
 
 // Button
-const btn = (cls: string | null, attrs: DomAttributes, label: string) => {
+const btn = (cls: string | null, attrs: Partial<DomAttributes>, label: string) => {
   return button(`.control.btn${cls}`, attrs, label);
 };
 
-const dropdown = (attrs: DomAttributes, options: HTMLOptionElement[]) => {
+const dropdown = (attrs: Partial<DomAttributes>, options: HTMLOptionElement[]) => {
   const selectVal = div('.select-val', 'Value');
   const selectEl = select('.select', attrs, ...options);
   selectVal.textContent = selectEl.options[selectEl.selectedIndex].text;
@@ -21,6 +21,7 @@ interface Stringable {
 }
 
 const enumDropdown = <ChoiceType extends Stringable>(
+  id: string,
   entries: [ChoiceType, string][],
   initialValue: ChoiceType,
   changeHandler: (a: ChoiceType) => any,
@@ -38,7 +39,7 @@ const enumDropdown = <ChoiceType extends Stringable>(
   };
 
   return dropdown(
-    { onchange: eventHandler },
+    { onchange: eventHandler, id },
     entries.map(entry => {
       const el = option({ value: entry[0] }, entry[1]);
       if (entry[0] === initialValue) {

--- a/src/controls/controls.scss
+++ b/src/controls/controls.scss
@@ -8,6 +8,21 @@ $btn-pad: 4px 8px;
 $btn-hover: rgba(0, 0, 0, 0.04);
 $btn-active: rgba(0, 0, 0, 0.08);
 
+@mixin withHover {
+  &:hover {
+    background: $btn-hover;
+  }
+
+  &:active {
+    background: $btn-active;
+  }
+}
+
+@mixin focusState {
+  outline: 0;
+  box-shadow: 0 0 0 1px var(--bindery-ui-bg), 0 0 0 3px rgba(0, 0, 0, 0.3);
+}
+
 .controls {
   font: 14px / 1.4 $system;
   display: none;
@@ -54,13 +69,8 @@ $btn-active: rgba(0, 0, 0, 0.08);
   margin-right: 8px;
   text-decoration: none;
 
-  &:hover {
-    background: $btn-hover;
-  }
+  @include withHover;
 
-  &:active {
-    background: $btn-active;
-  }
   &:last-child {
     margin-right: 0;
   }
@@ -92,6 +102,10 @@ $btn-active: rgba(0, 0, 0, 0.08);
     background: black;
     opacity: 1;
   }
+
+  &:focus {
+    @include focusState;
+  }
 }
 
 .view-row {
@@ -122,6 +136,7 @@ $btn-active: rgba(0, 0, 0, 0.08);
   position: relative;
 
   &:after {
+    // Draw dropdown
     content: '';
     position: absolute;
     right: 9px;
@@ -133,11 +148,10 @@ $btn-active: rgba(0, 0, 0, 0.08);
     border-top-color: currentColor;
   }
 
-  &:hover {
-    background-color: $btn-hover;
-  }
-  &:active {
-    background-color: $btn-hover;
+  @include withHover;
+
+  &:focus-within {
+    @include focusState;
   }
 }
 

--- a/src/controls/controls.scss
+++ b/src/controls/controls.scss
@@ -177,15 +177,11 @@ $btn-active: rgba(0, 0, 0, 0.08);
 }
 
 @media screen and (max-width: 960px) {
-  .in-progress {
+  .view-print, .view-preview {
     .controls {
-      background: transparent;
-      box-shadow: none;
+      background: var(--bindery-ui-bg);
+      flex-direction: column;  
     }
-  }
-  .controls {
-    background: var(--bindery-ui-bg);
-    flex-direction: column;
   }
 }
 

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -32,10 +32,10 @@ const renderPrintOptions = (state: ControlsState, actions: ControlsActions) => {
 
   return row(
     '.print-options',
-    row(null, enumDropdown(layoutLabels, state.layout, actions.setLayout)),
-    row(null, enumDropdown(sizeLabels, state.paper, actions.setPaper)),
+    row(null, enumDropdown('bindery-choose-layout', layoutLabels, state.layout, actions.setLayout)),
+    row(null, enumDropdown('bindery-choose-paper', sizeLabels, state.paper, actions.setPaper)),
     shouldShowMarks
-      ? row(null, enumDropdown(marksLabels, state.marks, actions.setMarks))
+      ? row(null, enumDropdown('bindery-choose-marks', marksLabels, state.marks, actions.setMarks))
       : '',
   );
 };
@@ -46,7 +46,13 @@ class Controls {
   update(state: ControlsState, actions: ControlsActions) {
     const oldElement = this.element;
     const newElement = this.render(state, actions);
+
+    const focusedId = document.hasFocus() ? document.activeElement?.id : undefined;
+
     oldElement.replaceWith(newElement);
+
+    if (focusedId) document.getElementById(focusedId)?.focus();
+
     this.element = newElement;
   }
 
@@ -60,7 +66,7 @@ class Controls {
 
     return div(
       '.controls',
-      row('.view-row', enumDropdown(modeLabels, state.mode, actions.setMode)),
+      row('.view-row', enumDropdown('bindery-choose-view', modeLabels, state.mode, actions.setMode)),
       shouldShowPrint ? renderPrintOptions(state, actions) : '',
       btn('.btn-print.btn-main', { onclick: print }, 'Print'),
     );

--- a/src/dom/dom.ts
+++ b/src/dom/dom.ts
@@ -6,17 +6,18 @@ const isFunc = (val: any) => typeof val === 'function';
 const isStr = (val: any) => typeof val === 'string';
 
 interface DomAttributes {
-  onchange?: (e: Event) => any;
-  onclick?: (e: Event) => any;
-  value?: any;
-  selected?: any;
-  disabled?: any;
+  id: String;
+  onchange: (e: Event) => any;
+  onclick: (e: Event) => any;
+  value: any;
+  selected: any;
+  disabled: any;
 }
 
 const h = (
   tagName: string,
   classNames: string | null,
-  attrs: DomAttributes,
+  attrs: Partial<DomAttributes>,
   ...children: (string | HTMLElement)[]
 ) => {
   const el = document.createElement(tagName);
@@ -42,19 +43,19 @@ const div = (cls: string, ...children: (string | HTMLElement)[]) => {
   return h('div', cls, {}, ...children) as HTMLDivElement;
 };
 
-const button = (cls: string, attrs: DomAttributes, label: string) => {
+const button = (cls: string, attrs: Partial<DomAttributes>, label: string) => {
   return h('button', cls, attrs, label) as HTMLButtonElement;
 };
 
 const select = (
   cls: string,
-  attrs: DomAttributes,
+  attrs: Partial<DomAttributes>,
   ...optionElements: HTMLOptionElement[]
 ) => {
   return h('select', cls, attrs, ...optionElements) as HTMLSelectElement;
 };
 
-const option = (attrs: DomAttributes, label: string) => {
+const option = (attrs: Partial<DomAttributes>, label: string) => {
   return h('option', null, attrs, label) as HTMLOptionElement;
 };
 

--- a/src/dom/dom.ts
+++ b/src/dom/dom.ts
@@ -20,7 +20,7 @@ const isObj = (val: any) => typeof val === 'object';
 const isFunc = (val: any) => typeof val === 'function';
 const isStr = (val: any) => typeof val === 'string';
 
-const isElementWrapper = (val: any): val is ElementWrapper => !!val.element && isElement(val.element);
+const isElementWrapper = (val: any): val is ElementWrapper => val?.element && isElement(val.element);
 
 export const h = (
   tagName: string,

--- a/src/dom/dom.ts
+++ b/src/dom/dom.ts
@@ -1,11 +1,6 @@
 import prefixer from './prefixer';
 
-const isElement = (node: any) => node.nodeType === Node.ELEMENT_NODE;
-const isObj = (val: any) => typeof val === 'object';
-const isFunc = (val: any) => typeof val === 'function';
-const isStr = (val: any) => typeof val === 'string';
-
-interface DomAttributes {
+export interface DomAttributes {
   id: String;
   onchange: (e: Event) => any;
   onclick: (e: Event) => any;
@@ -14,11 +9,24 @@ interface DomAttributes {
   disabled: any;
 }
 
-const h = (
+export interface ElementWrapper {
+  element: HTMLElement
+}
+
+type Appendable = string | HTMLElement | ElementWrapper;
+
+const isElement = (node: any) => node.nodeType === Node.ELEMENT_NODE;
+const isObj = (val: any) => typeof val === 'object';
+const isFunc = (val: any) => typeof val === 'function';
+const isStr = (val: any) => typeof val === 'string';
+
+const isElementWrapper = (val: any): val is ElementWrapper => !!val.element && isElement(val.element);
+
+export const h = (
   tagName: string,
   classNames: string | null,
   attrs: Partial<DomAttributes>,
-  ...children: (string | HTMLElement)[]
+  ...children: (Appendable)[]
 ) => {
   const el = document.createElement(tagName);
   if (classNames)
@@ -35,19 +43,23 @@ const h = (
       if (isFunc(v)) el[k] = v;
       else el.setAttribute(k, v);
     }
-  if (children) el.append(...children);
+  if (children) {
+    el.append(...children.map(item => {
+      return isElementWrapper(item) ? item.element : item;
+    }));
+  }
   return el;
 };
 
-const div = (cls: string, ...children: (string | HTMLElement)[]) => {
+export const div = (cls: string, ...children: Appendable[]) => {
   return h('div', cls, {}, ...children) as HTMLDivElement;
 };
 
-const button = (cls: string, attrs: Partial<DomAttributes>, label: string) => {
+export const button = (cls: string, attrs: Partial<DomAttributes>, label: string) => {
   return h('button', cls, attrs, label) as HTMLButtonElement;
 };
 
-const select = (
+export const select = (
   cls: string,
   attrs: Partial<DomAttributes>,
   ...optionElements: HTMLOptionElement[]
@@ -55,8 +67,6 @@ const select = (
   return h('select', cls, attrs, ...optionElements) as HTMLSelectElement;
 };
 
-const option = (attrs: Partial<DomAttributes>, label: string) => {
+export const option = (attrs: Partial<DomAttributes>, label: string) => {
   return h('option', null, attrs, label) as HTMLOptionElement;
 };
-
-export { h, div, button, select, option, DomAttributes };

--- a/src/makeBook/getContent.ts
+++ b/src/makeBook/getContent.ts
@@ -1,9 +1,7 @@
+import type { BookContent } from '../types';
 import { parseHTML } from '../dom';
 
-const fetchContent = async (
-  url: string,
-  selector?: string,
-): Promise<HTMLElement> => {
+const fetchContent = async (url: string, selector?: string): Promise<HTMLElement> => {
   const response = await fetch(url);
   if (response.status !== 200) {
     throw Error(`Response ${response.status}: Could not load file at "${url}"`);
@@ -18,9 +16,7 @@ const fetchContent = async (
   return el;
 };
 
-export const getContentAsElement = async (
-  content: any,
-): Promise<HTMLElement> => {
+export const getContentAsElement = async (content: BookContent): Promise<HTMLElement> => {
   if (content instanceof HTMLElement) return content;
   if (typeof content === 'string') {
     const el = document.querySelector(content);

--- a/src/rules/Counter.ts
+++ b/src/rules/Counter.ts
@@ -1,18 +1,20 @@
 import { Rule, RuleOptions } from './Rule';
 import { validateRuntimeOptions, RuntimeTypes } from '../runtimeOptionChecker';
+import { CSSSelector } from '../types';
+
 
 export interface CounterRuleOptions extends RuleOptions {
-  incrementEl: string;
-  resetEl: string;
-  replaceEl: string;
+  incrementEl: CSSSelector;
+  resetEl: CSSSelector;
+  replaceEl: CSSSelector;
   replace: (element: HTMLElement) => HTMLElement
 }
 
 class Counter extends Rule {
   counterValue: number;
-  incrementEl: string;
-  resetEl: string;
-  replaceEl: string;
+  incrementEl: CSSSelector;
+  resetEl: CSSSelector;
+  replaceEl: CSSSelector;
 
   constructor(options: Partial<CounterRuleOptions>) {
     super(options);

--- a/src/rules/Footnote.ts
+++ b/src/rules/Footnote.ts
@@ -1,11 +1,11 @@
 import Replace from './Replace';
 import { validateRuntimeOptions, RuntimeTypes } from '../runtimeOptionChecker';
 import { div } from '../dom';
-import { Book, Page } from '../book';
-import { PageMaker } from '../types';
+import { Book } from '../book';
+import { PageMaker, CSSSelector } from '../types';
 
 export interface FootnoteRuleOptions {
-  selector: string;
+  selector: CSSSelector;
   replace: (element: HTMLElement) => HTMLElement;
   render: (originalElement: HTMLElement, number: number) => string | HTMLElement;
 }

--- a/src/rules/FullBleedPage.ts
+++ b/src/rules/FullBleedPage.ts
@@ -2,10 +2,10 @@ import OutOfFlow from './OutOfFlow';
 import { validateRuntimeOptions, RuntimeTypes } from '../runtimeOptionChecker';
 import { div } from '../dom';
 import { Book } from '../book';
-import { PageMaker } from '../types';
+import { CSSSelector, PageMaker  } from '../types';
 
 export interface FullBleedPageRuleOptions {
-  selector: string;
+  selector: CSSSelector;
   continue: 'next' | 'same' | 'left' | 'right';
   rotate: 'none' | 'inward' | 'outward' | 'clockwise' | 'counterclockwise';
 }

--- a/src/rules/OutOfFlow.ts
+++ b/src/rules/OutOfFlow.ts
@@ -3,7 +3,7 @@ import { Book } from '../book';
 import { PageMaker } from '../types';
 import { RegionGetter } from 'regionize/dist/types/types';
 
-class OutOfFlow extends Rule {
+abstract class OutOfFlow extends Rule {
   continue?: string;
 
   constructor(options: {}) {
@@ -17,6 +17,7 @@ class OutOfFlow extends Rule {
     // Avoid breaking inside this element. Once it's completely added,
     // it will moved onto the background layer.
 
+    // TODO: this should be handled inside regionize
     elmt.setAttribute('data-ignore-overflow', 'true');
     return elmt;
   }

--- a/src/rules/PageBreak.ts
+++ b/src/rules/PageBreak.ts
@@ -2,9 +2,10 @@ import { Rule } from './Rule';
 import { validateRuntimeOptions, RuntimeTypes } from '../runtimeOptionChecker';
 import { Book } from '../book';
 import { RegionGetter } from 'regionize/dist/types/types';
+import { CSSSelector } from '../types';
 
 export interface PageBreakRuleOptions {
-  selector: string;
+  selector: CSSSelector;
   continue: 'next' | 'left' | 'right' | 'same';
   position: 'before' | 'after' | 'both' | 'avoid';
 }

--- a/src/rules/PageReference.ts
+++ b/src/rules/PageReference.ts
@@ -5,12 +5,14 @@ import { Book, Page, pageNumbersForTest } from '../book';
 import { shallowEqual, throttleTime } from '../utils';
 import { validateRuntimeOptions, RuntimeTypes } from '../runtimeOptionChecker';
 import { prefixer } from '../dom';
+import { CSSSelector } from '../types';
+
 
 // Compatible with ids that start with numbers
-const startsWithNumber = (sel: string) => {
+const startsWithNumber = (sel: CSSSelector) => {
   return sel.length > 2 && sel[0] === '#' && /^\d+$/.test(sel[1]);
 };
-const safeIDSel = (sel: string) => {
+const safeIDSel = (sel: CSSSelector) => {
   return startsWithNumber(sel) ? `[id="${sel.replace('#', '')}"]` : sel;
 };
 
@@ -24,7 +26,7 @@ interface PageReferenceInstance {
 }
 
 export interface PageReferenceRuleOptions {
-  selector: string,
+  selector: CSSSelector,
   replace: (element: HTMLElement, number: string | number) => HTMLElement,
   createTest: (element: HTMLElement) => TestFunction,
 }

--- a/src/rules/Replace.ts
+++ b/src/rules/Replace.ts
@@ -1,10 +1,10 @@
 import { Rule } from './Rule';
 import { Book } from '../book';
-import { PageMaker } from '../types';
+import { PageMaker, CSSSelector } from '../types';
 
 export interface ReplaceRuleOptions {
-  selector: string
-  replace: (element: HTMLElement, info?: any) => HTMLElement
+  selector: CSSSelector;
+  replace: (element: HTMLElement, info?: any) => HTMLElement;
 }
 
 class Replace extends Rule {

--- a/src/rules/Rule.ts
+++ b/src/rules/Rule.ts
@@ -2,6 +2,7 @@ import {
   RuleOptionBreakPosition,
   RuleOptionFlowPosition,
   RuleOptionPageRotation,
+  CSSSelector,
 } from '../types';
 
 export interface RuleOptions {
@@ -13,9 +14,9 @@ export interface RuleOptions {
   pageNumberOffset: number;
 }
 
-export class Rule {
+export abstract class Rule {
   name: string;
-  selector: string;
+  selector: CSSSelector;
   [key: string]: any;
 
   constructor(options: Partial<RuleOptions>) {

--- a/src/rules/Rule.ts
+++ b/src/rules/Rule.ts
@@ -14,7 +14,7 @@ export interface RuleOptions {
   pageNumberOffset: number;
 }
 
-export abstract class Rule {
+export class Rule {
   name: string;
   selector: CSSSelector;
   [key: string]: any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,11 @@
 import { Page } from './book';
 
+export type CSSSelector = string;
+
+interface RemoteBookContent { url: string, selector?: CSSSelector };
+
+export type BookContent = HTMLElement | CSSSelector | RemoteBookContent;
+
 export type PageMaker = () => Page;
 
 export type RuleOptionBreakPosition = 'before' | 'after' | 'both' | 'avoid';

--- a/src/viewer/Viewer.ts
+++ b/src/viewer/Viewer.ts
@@ -47,7 +47,6 @@ class Viewer {
   progressBar: HTMLElement;
   content: HTMLElement;
   scaler: HTMLElement;
-  zoomHolder: HTMLElement;
   element: HTMLElement;
   error?: HTMLElement;
 
@@ -213,7 +212,7 @@ class Viewer {
     this.show();
     if (!this.error) {
       this.error = errorView(title, text);
-      this.element.appendChild(this.error);
+      this.element.append(this.error);
       scrollToBottom();
       if (this.book) {
         const flow = this.book.currentPage.flow;

--- a/src/viewer/error.ts
+++ b/src/viewer/error.ts
@@ -4,7 +4,7 @@ import { div } from '../dom';
 
 declare const BINDERY_VERSION: string;
 
-export default function(title: string, text: string) {
+export default (title: string, text: string) => {
   return div(
     '.error',
     div('.error-title', title),

--- a/src/viewer/flipbookViewer.scss
+++ b/src/viewer/flipbookViewer.scss
@@ -1,25 +1,53 @@
-.view-flip .zoom-scaler {
-  transform-origin: center left;
+.root.view-flip {
+  max-height: 100vh;
+}
+
+@mixin pinned-absolute {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  margin: auto;
+}
+
+.view-flip {
+  .zoom-holder {
+    @include pinned-absolute();
+    display: block;
+  }
+
+  .zoom-scaler {
+    @include pinned-absolute();
+    transform-origin: center;
+
+    width: 0;
+    height: 0;
+  }
+
+  .zoom-content {
+    min-width: 0; //calc(1.1 * var(--bindery-spread-width));
+  }
 }
 
 .flap-holder {
   perspective: 5000px;
   transform-style: preserve-3d;
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  bottom: 0;
-  margin: auto;
-  transform-style: preserve-3d;
+  @include pinned-absolute();
 }
 
-.flip-sizer {
-  position: relative;
-  margin: auto;
-  padding: 0 20px;
-  box-sizing: content-box;
-  height: 90vh !important;
+.flipbook-sizer {
+  // Larger than a spread to accomadate the 3d effect
+  --bindery-flipbook-width: calc(var(--bindery-spread-width) * 1.15);
+  --bindery-flipbook-height: calc(var(--bindery-page-height) * 1.05);
+
+  position: absolute;
+
+  width: var(--bindery-flipbook-width);
+  height: var(--bindery-flipbook-height);
+
+  top: calc(var(--bindery-flipbook-height) * -0.5);
+  left: calc(var(--bindery-flipbook-width) * -0.5);
 }
 
 .page3d {

--- a/src/viewer/flipbookViewer.ts
+++ b/src/viewer/flipbookViewer.ts
@@ -8,8 +8,8 @@ const renderFlipbookViewer = (bookPages: Page[], doubleSided: boolean) => {
   const flipLayout = document.createDocumentFragment();
   const sizer = div('.spread-size.flip-sizer');
   const flapHolder = div('.spread-size.flap-holder');
-  sizer.appendChild(flapHolder);
-  flipLayout.appendChild(sizer);
+  sizer.append(flapHolder);
+  flipLayout.append(sizer);
 
   const flaps: HTMLElement[] = [];
 
@@ -21,10 +21,10 @@ const renderFlipbookViewer = (bookPages: Page[], doubleSided: boolean) => {
   }
   flapHolder.style.width = `${pages.length * leftOffset}px`;
 
-  const setLeaf = (n: number) => {
-    let newLeaf = n;
-    if (newLeaf === currentLeaf) newLeaf += 1;
-    currentLeaf = newLeaf;
+  const setLeaf = (unclamped: number) => {
+    let n = unclamped;
+    if (n === currentLeaf) n += 1;
+    const newLeaf = Math.min(Math.max(0, n), flaps.length);
 
     let zScale = 4;
     if (flaps.length * zScale > 200) zScale = 200 / flaps.length;
@@ -36,6 +36,8 @@ const renderFlipbookViewer = (bookPages: Page[], doubleSided: boolean) => {
         i < newLeaf ? 4 : 0
       }px,0,${z}px) rotateY(${i < newLeaf ? -180 : 0}deg)`;
     });
+
+    currentLeaf = newLeaf;
   };
 
   let leafIndex = 0;
@@ -43,6 +45,7 @@ const renderFlipbookViewer = (bookPages: Page[], doubleSided: boolean) => {
     leafIndex += 1;
     const li = leafIndex;
     const flap = div('.page3d');
+
     flap.addEventListener('click', () => {
       const newLeaf = li - 1;
       setLeaf(newLeaf);
@@ -51,7 +54,7 @@ const renderFlipbookViewer = (bookPages: Page[], doubleSided: boolean) => {
     const rightPage = pages[i].element;
     let leftPage;
     rightPage.classList.add(prefixer('page3d-front'));
-    flap.appendChild(rightPage);
+    flap.append(rightPage);
     if (doubleSided) {
       flap.classList.add(prefixer('doubleSided'));
       leftPage = pages[i + 1].element;
@@ -59,20 +62,24 @@ const renderFlipbookViewer = (bookPages: Page[], doubleSided: boolean) => {
       leftPage = div('.page');
     }
     leftPage.classList.add(prefixer('page3d-back'));
-    flap.appendChild(leftPage);
+    flap.append(leftPage);
 
-    // TODO: Dynamically add/remove pages.
-    // Putting 1000s of elements onscreen
-    // locks up the browser.
+    // TODO: Virtualize stack of pages.
+    // Putting 1000s of elements onscreen,
+    // espacially as 3d layers, locks up the browser.
 
     flap.style.left = `${i * leftOffset}px`;
 
     flaps.push(flap);
-    flapHolder.appendChild(flap);
+    flapHolder.append(flap);
   }
 
   setLeaf(0);
-  return flipLayout;
+  return {
+    element: flipLayout,
+    next: () => setLeaf(currentLeaf + 1),
+    previous: () => setLeaf(currentLeaf - 1),
+  }
 };
 
 export { renderFlipbookViewer };

--- a/src/viewer/flipbookViewer.ts
+++ b/src/viewer/flipbookViewer.ts
@@ -6,7 +6,7 @@ const renderFlipbookViewer = (bookPages: Page[], doubleSided: boolean) => {
   const pages = padPages(bookPages, () => new Page());
 
   const flipLayout = document.createDocumentFragment();
-  const sizer = div('.spread-size.flip-sizer');
+  const sizer = div('.flipbook-sizer');
   const flapHolder = div('.spread-size.flap-holder');
   sizer.append(flapHolder);
   flipLayout.append(sizer);
@@ -77,6 +77,7 @@ const renderFlipbookViewer = (bookPages: Page[], doubleSided: boolean) => {
   setLeaf(0);
   return {
     element: flipLayout,
+    contentSizer: sizer,
     next: () => setLeaf(currentLeaf + 1),
     previous: () => setLeaf(currentLeaf - 1),
   }

--- a/src/viewer/flipbookViewer.ts
+++ b/src/viewer/flipbookViewer.ts
@@ -1,8 +1,8 @@
 import { Page } from '../book';
-import { prefixer, div } from '../dom';
+import { prefixer, div, ElementWrapper } from '../dom';
 import padPages from './padPages';
 
-const renderFlipbookViewer = (bookPages: Page[], doubleSided: boolean) => {
+const renderFlipbookViewer = (bookPages: ElementWrapper[], doubleSided: boolean) => {
   const pages = padPages(bookPages, () => new Page());
 
   const flipLayout = document.createDocumentFragment();

--- a/src/viewer/gridViewer.ts
+++ b/src/viewer/gridViewer.ts
@@ -25,7 +25,9 @@ const renderGridViewer = (bookPages: Page[], isTwoUp: boolean) => {
     });
   }
 
-  return gridLayout;
+  return {
+    element: gridLayout,
+  };
 };
 
 export { renderGridViewer };

--- a/src/viewer/gridViewer.ts
+++ b/src/viewer/gridViewer.ts
@@ -1,5 +1,5 @@
 import { Page } from '../book';
-import { div } from '../dom';
+import { div, ElementWrapper } from '../dom';
 import padPages from './padPages';
 
 const twoPageSpread = (...children: HTMLElement[]) => {
@@ -9,7 +9,7 @@ const onePageSpread = (...children: HTMLElement[]) => {
   return div('.spread-wrapper.spread-centered.page-size', ...children);
 };
 
-const renderGridViewer = (bookPages: Page[], isTwoUp: boolean) => {
+const renderGridViewer = (bookPages: ElementWrapper[], isTwoUp: boolean) => {
   const pages = isTwoUp ? padPages(bookPages, () => new Page()) : bookPages;
 
   const gridLayout = document.createDocumentFragment();

--- a/src/viewer/layouts.test.ts
+++ b/src/viewer/layouts.test.ts
@@ -12,30 +12,30 @@ const pages = [
 
 test('creates two-up grid layout', () => {
   const grid = renderGridViewer(pages, true);
-  expect(grid instanceof DocumentFragment).toBe(true);
+  expect(grid.element instanceof DocumentFragment).toBe(true);
 });
 
 test('creates one-up grid layout', () => {
   const grid = renderGridViewer(pages, false);
-  expect(grid instanceof DocumentFragment).toBe(true);
+  expect(grid.element instanceof DocumentFragment).toBe(true);
 });
 
 test('creates flip layout', () => {
   const flip = renderFlipbookViewer(pages, true);
-  expect(flip instanceof DocumentFragment).toBe(true);
+  expect(flip.element instanceof DocumentFragment).toBe(true);
 });
 
 test('creates print single layout', () => {
   const print = renderSheetViewer(pages, false, SheetLayout.PAGES);
-  expect(print instanceof DocumentFragment).toBe(true);
+  expect(print.element instanceof DocumentFragment).toBe(true);
 });
 
 test('creates print spread layout', () => {
   const print = renderSheetViewer(pages, false, SheetLayout.SPREADS);
-  expect(print instanceof DocumentFragment).toBe(true);
+  expect(print.element instanceof DocumentFragment).toBe(true);
 });
 
 test('creates print booklet layout', () => {
   const print = renderSheetViewer(pages, false, SheetLayout.BOOKLET);
-  expect(print instanceof DocumentFragment).toBe(true);
+  expect(print.element instanceof DocumentFragment).toBe(true);
 });

--- a/src/viewer/orderPagesBooklet.ts
+++ b/src/viewer/orderPagesBooklet.ts
@@ -1,13 +1,12 @@
-import { Page } from '../book';
-import { PageMaker } from '../types';
+import { ElementWrapper } from '../dom';
 
-const orderPagesBooklet = (pages: Page[], makePage: PageMaker) => {
+const orderPagesBooklet = <T extends ElementWrapper>(pages: T[], makePage: () => T) => {
   while (pages.length % 4 !== 0) {
     const spacerPage = makePage();
     spacerPage.element.style.visibility = 'hidden';
     pages.push(spacerPage);
   }
-  const bookletOrder: Page[] = [];
+  const bookletOrder: T[] = [];
   const len = pages.length;
 
   for (let i = 0; i < len / 2; i += 2) {

--- a/src/viewer/padPages.ts
+++ b/src/viewer/padPages.ts
@@ -1,7 +1,6 @@
-import { Page } from '../book';
-import { PageMaker } from '../types';
+import type { ElementWrapper } from '../dom';
 
-const padPages = (pages: Page[], makePage: PageMaker) => {
+const padPages = <T extends ElementWrapper>(pages: T[], makePage: () => T) => {
   if (pages.length % 2 !== 0) {
     const pg = makePage();
     pages.push(pg);

--- a/src/viewer/sheetViewer.ts
+++ b/src/viewer/sheetViewer.ts
@@ -58,7 +58,9 @@ const renderSheetViewer = (
     });
   }
 
-  return printLayout;
+  return {
+    element: printLayout,
+  };
 };
 
 export { renderSheetViewer };

--- a/src/viewer/sheetViewer.ts
+++ b/src/viewer/sheetViewer.ts
@@ -1,4 +1,4 @@
-import { div, classes } from '../dom';
+import { div, classes, ElementWrapper } from '../dom';
 import { Page } from '../book';
 import { SheetLayout } from '../constants';
 
@@ -14,7 +14,7 @@ const onePageSpread = (...children: HTMLElement[]) => {
 };
 
 const renderSheetViewer = (
-  bookPages: Page[],
+  bookPages: ElementWrapper[],
   _doubleSided: boolean,
   layout: SheetLayout,
 ) => {
@@ -43,15 +43,16 @@ const renderSheetViewer = (
         spreadMarks.appendChild(meta);
       }
       const sheet = printSheet(
-        div('.page-bleed-clip.page-bleed-clip-left', pages[i].element),
-        div('.page-bleed-clip.page-bleed-clip-right', pages[i + 1].element),
+        div('.page-bleed-clip.page-bleed-clip-left', pages[i]),
+        div('.page-bleed-clip.page-bleed-clip-right', pages[i + 1]),
         spreadMarks,
       );
       sheet.classList.add(classes.sheetSpread);
       printLayout.appendChild(sheet);
     }
   } else {
-    pages.forEach(pg => {
+    pages.forEach(p => {
+      const pg = p as Page;
       const sheet = printSheet(pg.element, marks());
       sheet.classList.add(pg.isLeft ? classes.sheetLeft : classes.sheetRight);
       printLayout.appendChild(sheet);

--- a/src/viewer/viewer.scss
+++ b/src/viewer/viewer.scss
@@ -37,15 +37,9 @@
   .zoom-content {
     padding: 10px;
     background: var(--bindery-ui-bg);
-    // position: absolute;
-    left: 0;
-    right: 0;
     margin: auto;
     .view-preview & {
       min-width: calc(20px + var(--bindery-spread-width));
-    }
-    .view-flip & {
-      min-width: calc(1.1 * var(--bindery-spread-width));
     }
     .view-print & {
       min-width: calc(20px + var(--bindery-sheet-width));
@@ -174,7 +168,6 @@
 .zoom-scaler {
   transform-origin: top left;
   transform-style: preserve-3d;
-  // height: calc(100vh - 120px); // adjust scrollheight on scaled down
 }
 
 .print-sheet {


### PR DESCRIPTION
Addresses #88 
- Show focus ring when tabbing between option dropdowns
- Use left/right arrow keys to flip

Refactors viewer sizing a bit to make sure flipbook scales down on short and/or narrow screens.

Also adds stricter TS types in a few places